### PR TITLE
Lake formation deny admin

### DIFF
--- a/guardrails/aws-marketplace/AWS-Marketplace-Unsubscribe.json
+++ b/guardrails/aws-marketplace/AWS-Marketplace-Unsubscribe.json
@@ -1,0 +1,40 @@
+{
+    "Identifier": "AWS-Marketplace-Unsubscribe",
+    "Guardrail": "Protect aganist canceling your products subscription in AWS Marketplace",
+    "Rationale": [
+        "AWS Marketplace is a digital catalog with thousands of software listings from independent software vendors that make it easy to find, test, buy, and deploy software that runs on AWS.",
+        "Unauthorized modifications to your subscription could affect your workloads in AWS accounts."
+    ],
+    "References": [
+                 "https://aws.amazon.com/premiumsupport/knowledge-center/cancel-marketplace-subscription",
+                 "https://aws.amazon.com/marketplace"
+    ],
+    "Test Scenarios": [
+        {
+            "Test-Scenario": "Unsubscribe software products from AWS Marketplace",
+            "Steps": [
+                    "1.Prerequisite: Subscribed products",
+                    "2.Login into AWS Account", 
+                    "3.Search for 'AWS Marketplace Subscriptions' service in console",
+                    "4.On the Manage subscriptions page, choose Manage next to the software subscription that you want to cancel.",
+                    "5.Choose Actions, and then choose Cancel subscription.",
+                    "6.Select the check box to acknowledge that running instances are charged to your account, and then choose Yes, cancel subscription."
+            ],
+            "Expected-Result": "User is not authorized to perform: aws-marketplace:Unsubscribe on resource"
+        }
+    ],
+    "Policy": "DenyUnsubscribeAWSMarketPlace",
+     "Version":"2012-10-17",
+     "Statement":[
+		{
+			"Sid": "DenyUnsubscribeAWSMarketPlace",
+			"Effect": "Deny",
+			"Action": [
+				"aws-marketplace:Unsubscribe"
+			],
+			"Resource": [
+				"*"
+			]
+		}
+	]
+}

--- a/guardrails/lakeformation/Deny-Lakeformation-Admin-Operations.json
+++ b/guardrails/lakeformation/Deny-Lakeformation-Admin-Operations.json
@@ -9,7 +9,7 @@
         "A principal is granted the necessary authorizations by the data lake administrator or another principal with the permissions to grant Lake Formation permissions.",
         "When you grant a Lake Formation permission to a principal, you can optionally grant the ability to pass that permission to another principal.",
         "A principal with IAM administrative permissions—for example, with the AdministratorAccess AWS managed policy—has permissions to grant Lake Formation permissions and create data lake administrators.", 
-        "To deny a user or role access to Lake Formation administrator operations in your accout, attach below SCP API operations."
+        "To deny a user or role access to Lake Formation administrator operations in your accout, attach below SCP policy"
     ],
     "References": [
                  "https://docs.aws.amazon.com/lake-formation/latest/dg/what-is-lake-formation.html",

--- a/guardrails/lakeformation/Deny-Lakeformation-Admin-Operations.json
+++ b/guardrails/lakeformation/Deny-Lakeformation-Admin-Operations.json
@@ -1,0 +1,49 @@
+{
+    "Identifier": "Deny-Lakeformation-Admin-Operations",
+    "Guardrail": "To prevent users from adding themselves as an administrator with an extract, transform, and load (ETL) script, make sure that all non-administrator users and roles are denied access to these API operations.",
+    "Rationale": [
+        "AWS Lake Formation is a fully managed service that makes it easier for you to build, secure, and manage data lakes.",
+        "AWS Lake Formation Administrators can view all metadata in the AWS Glue Data Catalog. They can also grant and revoke permissions on data resources to principals, including themselves.",
+
+        "AWS Lake Formation requires that each principal (user or role) be authorized to perform actions on Lake Formation–managed resources.", 
+        "A principal is granted the necessary authorizations by the data lake administrator or another principal with the permissions to grant Lake Formation permissions.",
+        "When you grant a Lake Formation permission to a principal, you can optionally grant the ability to pass that permission to another principal.",
+        
+        "A principal with IAM administrative permissions—for example, with the AdministratorAccess AWS managed policy—has permissions to grant Lake Formation permissions and create data lake administrators.", 
+        "To deny a user or role access to Lake Formation administrator operations in your accout, attach below SCP API operations."
+    ],
+    "References": [
+                 "https://docs.aws.amazon.com/lake-formation/latest/dg/what-is-lake-formation.html",
+                 "https://docs.aws.amazon.com/lake-formation/latest/dg/required-permissions-for-grant.html"
+    ],
+    "Test Scenarios": [
+        {
+            "Test-Scenario": "Grand IAM user and roles as AWS Lake Formation Admin",
+            "Steps": [
+                    "1.Prerequisite: Access to AWS Lake Foramtion Service",
+                    "2.Login into AWS Account", 
+                    "3.Search for 'AWS Lake Foramtion Service",
+                    "4.Under the Permissions section, click on Administrative roles and tasks",
+                    "5.Click on Choose Administrators",
+                    "6.Select IAM user or roles",
+                    "7.Click Save"
+            ],
+            "Expected-Result": "User is not authorized to perform: lakeformation:PutDataLakeSettings on resource with an explicit deny"
+        }
+    ],
+    "Policy": "DenyLakeFormationAdministratorOperations",
+     "Version":"2012-10-17",
+     "Statement":[
+		{
+			"Sid": "DenyLakeFormationAdministratorOperations",
+			"Effect": "Deny",
+			"Action": [
+				"lakeformation:GetDataLakeSettings",
+                "lakeformation:PutDataLakeSettings"
+			],
+			"Resource": [
+				"*"
+			]
+		}
+	]
+}

--- a/guardrails/lakeformation/Deny-Lakeformation-Admin-Operations.json
+++ b/guardrails/lakeformation/Deny-Lakeformation-Admin-Operations.json
@@ -8,7 +8,6 @@
         "AWS Lake Formation requires that each principal (user or role) be authorized to perform actions on Lake Formation–managed resources.", 
         "A principal is granted the necessary authorizations by the data lake administrator or another principal with the permissions to grant Lake Formation permissions.",
         "When you grant a Lake Formation permission to a principal, you can optionally grant the ability to pass that permission to another principal.",
-        
         "A principal with IAM administrative permissions—for example, with the AdministratorAccess AWS managed policy—has permissions to grant Lake Formation permissions and create data lake administrators.", 
         "To deny a user or role access to Lake Formation administrator operations in your accout, attach below SCP API operations."
     ],


### PR DESCRIPTION
Issue number:
32

Description:

To prevent users from adding themselves as an administrator with an extract, transform, and load (ETL) script, make sure that all non-administrator users and roles are denied access to these API operations.


Branch name: Master

File/folder affected : 
guardrails/lakeformation/Deny-Lakeformation-Admin-Operations.json

Changes proposed: 
<Detailed description (including line numbers, if applicable) of what the changes are>
