### PR TITLE
Add SCP to Prevent Users from Deleting AWS Access Analyzer in an Account

### DIFF
--- a/guardrails/iam/SCP-IAM-7.json
+++ b/guardrails/iam/SCP-IAM-7.json
@@ -1,0 +1,26 @@
+{
+    "Identifier": "SCP-IAM-7",
+    "Guardrail": "Prevent Users from Deleting AWS Access Analyzer in an Account",
+    "Rationale": [
+        "Access Analyzer is often used to detect anomalous user behavior, a user deleting this may be trying to conceal their activities."
+    ], 
+    "Test Scenarios": [
+        {
+            "Test-Scenario": "Create new user",
+            "Steps": [
+                "Log in to the AWS console with a role that is allowed to delete access analyzer", 
+                "Delete access analyzer"
+            ],
+            "Expected-Result": "Access Denied"
+        }
+    ],
+    "References": [
+        "https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html"
+    ],
+    "Policy-Type": "SCP",
+    "SCP-Type": "Prevent-All",
+    "IAM Actions": [
+        "access-analyzer:DeleteAnalyzer"
+    ],
+    "Resource": ["*"]
+}


### PR DESCRIPTION
Issue number: #44 

Description: Refer to issue #44 for more details

Branch name: master

File/folder affected : /guardrails/iam

Changes proposed: 
Add SCP .json to prevent deletion of IAM Access Analyzer