### PR TITLE
remove extra condition

### DIFF
--- a/docs/guardrails/scp-guardrails.md
+++ b/docs/guardrails/scp-guardrails.md
@@ -1104,11 +1104,6 @@ layout: default
   "Condition": {
         "Null": {
             "s3:x-amz-server-side-encryption": "true"
-        },
-        "StringNotEquals": {
-            "s3:x-amz-server-side-encryption": [
-                "aws:kms"
-            ]
         }
     }
 }

--- a/guardrails/s3/SCP-S3-2.json
+++ b/guardrails/s3/SCP-S3-2.json
@@ -27,12 +27,7 @@
         {
             "Null": {
                 "s3:x-amz-server-side-encryption": "true"
-             },
-             "StringNotEquals": {
-                "s3:x-amz-server-side-encryption": [
-                   "aws:kms"
-                ]
-             }
+            }
         }
     ],
     "Category": "Mandatory"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Issue number: N/A

Description: Remove extra condition from S3-2 SCP

Branch name: master

File/folder affected : docs/guardrails/scp-guardrails.md guardrails/s3/SCP-S3-2.json

Changes proposed: 
The two conditions for the SCP previously would deny `s3:PutObject` if the `x-amz-server-side-encryption` key is both 

1) null, and 
2) set to something other than `aws:kms` (SSE-KMS encryption). 

You might see the problem here - it is impossible for the header to be null and set to a string at the same time. Since the conditions are logically ANDed, they will always fail (and the action will NOT be denied) if the header is present at all - allowing any type of encryption (but it does block unencrypted `PutObject `calls as-is - whew!).

After discussion with Josh, the guardrail "Prevent S3 unencrypted object uploads" is still being enforced and the rationale  "Security policies require that all S3 objects are encrypted when uploaded to buckets" is met. So I have removed the `StringNotEquals` condition as it is superfluous.

